### PR TITLE
Option to disable mousewheel

### DIFF
--- a/bootstrap-touchspin/bootstrap.touchspin.js
+++ b/bootstrap-touchspin/bootstrap.touchspin.js
@@ -81,7 +81,8 @@
                     postfix: "",
                     booster: true,
                     boostat: 10,
-                    maxboostedstep: false
+                    maxboostedstep: false,
+                    mousewheel: true
                 }, options);
             }
 
@@ -256,19 +257,21 @@
                     stopSpin();
                 });
 
-                originalinput.bind("mousewheel DOMMouseScroll", function(ev) {
-                    var delta = ev.originalEvent.wheelDelta || -ev.originalEvent.detail;
+                if (settings.mousewheel) {
+                    originalinput.bind("mousewheel DOMMouseScroll", function(ev) {
+                        var delta = ev.originalEvent.wheelDelta || -ev.originalEvent.detail;
 
-                    ev.stopPropagation();
-                    ev.preventDefault();
+                        ev.stopPropagation();
+                        ev.preventDefault();
 
-                    if (delta < 0) {
-                        downOnce();
-                    }
-                    else {
-                        upOnce();
-                    }
-                });
+                        if (delta < 0) {
+                            downOnce();
+                        }
+                        else {
+                            upOnce();
+                        }
+                    });
+                }
             }
 
             function _bindEventsInterface() {


### PR DESCRIPTION
I think you should provide this option.  changing values with the
mousewheel is maybe nice, nevertheless it can cause uncommon behavior:
- your mouse is somewhere on the screen
- you scroll down or up by using the mouswheel
- now it can happen that the mousepointer unfortunately stays over an
  touchspin input
  ==> it stops scrolling the screen and changing the value instead. and
  maybe the user did not realize this because he moves the mouse a bit
  while scrolling (or because scrolling has stopped) and the value is
  accidentally changed.
