### PR TITLE
Update for npm; minor version bump

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-touchspin",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "homepage": "http://www.virtuosoft.eu/code/bootstrap-touchspin/",
   "authors": [
     {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "name": "István Ujj-Mészáros",
     "url": "https://github.com/istvan-ujjmeszaros"
   },
+  "main": "dist/jquery.bootstrap-touchspin.js",
   "contributors": [
     {
       "name": "István Ujj-Mészáros",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "http://github.com/istvan-ujjmeszaros/bootstrap-touchspin.git"
   },
   "homepage": "http://www.virtuosoft.eu/code/bootstrap-touchspin/",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.13",


### PR DESCRIPTION
Adds a `main` property to the `package.json` (for browserfiy and similar tools).  Bumps the minor version accordingly.

If you have an account on npm, please let me know and I'll gladly add you as a contributor so you can own and update it.