### PR TITLE
added main field to bower.json file for wiredep support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,10 @@
     "bootstrap": ">=3.0.0"
   },
   "license": "Apache License, Version 2.0",
+  "main": [
+    "src/jquery.bootstrap-touchspin.css",
+    "src/jquery.bootstrap-touchspin.js"
+  ],
   "keywords": [
     "jquery",
     "plugin",


### PR DESCRIPTION
Hi there,

This addresses issue #44, which was a request to add the `"main"` property in the `bower.json` file. This will enable [wiredep](https://github.com/taptapship/wiredep) support for those using it without causing in compatible issues for those who are not.