### PR TITLE
Use SPDX license identifier

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "jquery": ">=1.9.0",
     "bootstrap": ">=3.0.0"
   },
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "main": [
     "src/jquery.bootstrap-touchspin.css",
     "src/jquery.bootstrap-touchspin.js"


### PR DESCRIPTION
Otherwise http://www.webjars.org/bower complains with:

```
Failed!
No valid licenses found. Detected licenses: Apache License, Version 2.0
The acceptable licenses on BinTray are at: https://bintray.com/docs/api/#_footnote_1
License detection first uses the package metadata (e.g. package.json or bower.json) and falls back to looking for a LICENSE, LICENSE.txt, or LICENSE.md file in the master branch of the GitHub repo.
Since these methods failed to detect a valid license you will need to work with the upstream project to add discoverable license metadata to a release or to the GitHub repo.

If you feel you have reached this failure in error, please file an issue: https://github.com/webjars/webjars/issues

Created Bower WebJar
Fetched Bower zip
Generated POM
Converted dependencies to Maven
Got Bower info
Determined Artifact Name: bootstrap-touchspin
Starting Deploy
```
