### PR TITLE
Update postfix and prefix if settings change.

### DIFF
--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -164,6 +164,15 @@
 
       function _updateSettings(newsettings) {
         settings = $.extend({}, settings, newsettings);
+
+
+        // Update postfix and prefix texts if those settings were changed.
+        if (newsettings.postfix) {
+          originalinput.parent().find('.bootstrap-touchspin-postfix').text(newsettings.postfix);
+        }
+        if (newsettings.prefix) {
+          originalinput.parent().find('.bootstrap-touchspin-prefix').text(newsettings.prefix);
+        }
       }
 
       function _buildHtml() {


### PR DESCRIPTION
## Why?
When `touchspin.updatesettings` is triggered it does not refresh the text in the postfix and prefix elements.

## What?
This will update the text in the postfix/prefix if settings change.