### PR TITLE
setting value to integer by parseFloat settings.min

### DIFF
--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -623,7 +623,7 @@
         value = value - boostedstep;
 
         if (value < settings.min) {
-          value = settings.min;
+          value = parseFloat(settings.min);
           originalinput.trigger('touchspin.on.min');
           stopSpin();
         }


### PR DESCRIPTION
When value is smaller the settings.min value is assigned with
settings.min which is a string.
Latter on value.toFixed(settings.decimals) will fail if value is string
so we need to parseFloat settings.min when assigning it to value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istvan-ujjmeszaros/bootstrap-touchspin/80)
<!-- Reviewable:end -->
