### PR TITLE
bs4 ans some little changes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Bootstrap TouchSpin
-v3.1.2
+v4.0.0
 
 A mobile and touch friendly input spinner component for Bootstrap 3.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bootstrap TouchSpin [![Build Status](https://secure.travis-ci.org/istvan-ujjmeszaros/bootstrap-touchspin.png?branch=master)](https://travis-ci.org/istvan-ujjmeszaros/bootstrap-touchspin)
 
-##### Bootstrap TouchSpin is a mobile and touch friendly input spinner component for Bootstrap 3.
+##### Bootstrap TouchSpin is a mobile and touch friendly input spinner component for Bootstrap 3 & 4.
 
 - [Website](http://www.virtuosoft.eu/code/bootstrap-touchspin/)
 

--- a/bootstrap-touchspin.jquery.json
+++ b/bootstrap-touchspin.jquery.json
@@ -1,7 +1,7 @@
 {
     "name": "bootstrap-touchspin",
     "title": "Bootstrap TouchSpin",
-    "description": "A mobile and touch friendly input spinner component for Bootstrap 3.",
+    "description": "A mobile and touch friendly input spinner component for Bootstrap 3 & 4.",
     "keywords": [
         "input",
         "bootstrap",
@@ -10,7 +10,7 @@
         "spinbutton",
         "spinner"
     ],
-    "version": "3.1.2",
+    "version": "4.0.0",
     "author": {
         "name": "István Ujj-Mészáros",
         "url": "https://github.com/istvan-ujjmeszaros"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-touchspin",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "homepage": "http://www.virtuosoft.eu/code/bootstrap-touchspin/",
   "authors": [
     {
@@ -8,7 +8,7 @@
       "url": "https://github.com/istvan-ujjmeszaros"
     }
   ],
-  "description": "Bootstrap TouchSpin is a mobile and touch friendly input spinner component for Bootstrap 3.",
+  "description": "Bootstrap TouchSpin is a mobile and touch friendly input spinner component for Bootstrap 3 & 4.",
   "dependencies": {
     "jquery": ">=1.9.0",
     "bootstrap": ">=3.0.0"

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -87,96 +87,6 @@ small {
     font-size: 12px;
 }
 
-.navbar-brand {
-    padding: 5px 0px 5px;
-}
-
-.navbar-default {
-    font-family: "Century Gothic", Arial, sans-serif;
-    background: #000 url(img/bg-menu.png) repeat-x left top; /*#377fa0;*/
-    color: #fff;
-    text-transform: uppercase;
-    border: none;
-    box-shadow: 0px 0px 1px #000;
-    /*background-image: linear-gradient(to top, rgb(62, 86, 112) 0%, rgb(69, 94, 122) 100%)*/;
-}
-
-.navbar-default .navbar-nav > .dropdown > a .caret,
-.navbar-default .navbar-nav > .dropdown > a:hover .caret,
-.navbar-default .navbar-nav > .dropdown > a:focus .caret {
-    border-top-color: #fff;
-    border-bottom-color: #fff;
-}
-
-.navbar > .container .navbar-brand {
-    margin-left: 0;
-}
-
-.navbar .nav > li > a {
-    color: #fff;
-}
-
-.navbar-default .navbar-brand,
-.navbar-default .navbar-brand:hover,
-.navbar-default .navbar-brand:focus {
-    color: #fff;
-}
-
-.navbar .nav > .active {
-}
-
-.navbar .nav > .active > a,
-.navbar .nav > .active > a:hover,
-.navbar .nav > .active > a:focus,
-.navbar .nav li.dropdown.active > .dropdown-toggle,
-.navbar .nav li.dropdown.open.active > .dropdown-toggle {
-    background: url(img/bg-menu-selected.png) no-repeat center bottom; /*#a5360f;*/
-    background: #BC451B;
-    color: #fff;
-    /*height: 65px;*/
-}
-
-.navbar .nav > li > a:focus,
-.navbar .nav > li > a:hover,
-.navbar .nav li.dropdown.open > .dropdown-toggle {
-    background: rgba(188, 69, 27, 0.6);
-    color: #fff;
-}
-
-
-.dropdown-menu {
-    border-radius: 0;
-    padding: 10px 0;
-}
-
-.dropdown-menu > li > a:hover, .dropdown-menu > li > a:focus, .dropdown-submenu:hover > a, .dropdown-submenu:focus > a,
-.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {
-    background: #d64513;
-}
-
-.nav-tabs .open .dropdown-toggle, .nav-pills .open .dropdown-toggle, .nav > li.dropdown.open.active > a:hover {
-    border: none;
-}
-
-.dropdown-menu > li > a {
-    padding: 10px 20px;
-    color: #585858;
-}
-
-.navbar .addthis_toolbox {
-    margin-top: 9px;
-    float: right;
-    margin-left: 15px;
-}
-
-.navbar .followus {
-    display: none;
-    float: right;
-    color: white;
-    margin-top: 15px;
-    margin-right: 10px;
-}
-
 .panel {
     border-radius: 10px;
     background: #f5f5f5;
@@ -216,43 +126,6 @@ small {
     background: #a5360f;
 }
 
-.socialbuttons,
-.addthis_toolbox {
-    min-height: 26px;
-}
-
-.row-fluid .socialbuttons {
-    margin-bottom: 15px;
-}
-
-.navbar .socialbuttons {
-    float: right;
-    height: 20px;
-    width: 220px;
-    white-space: nowrap;
-    margin-top: 15px;
-}
-
-.navbar .btn-navbar {
-    background: #474747;
-    -webkit-box-shadow: none;
-    -moz-box-shadow: none;
-    box-shadow: none;
-}
-
-.navbar .btn-navbar {
-    background: #a5360f;
-    border: none;
-    border-radius: 0;
-}
-
-.navbar .btn-navbar:hover, .navbar .btn-navbar:focus, .navbar .btn-navbar:active, .navbar .btn-navbar.active, .navbar .btn-navbar.disabled, .navbar .btn-navbar[disabled] {
-    background: #474747;
-}
-
-.nav-collapse .nav > li > a, .nav-collapse .dropdown-menu a {
-    border-radius: 0;
-}
 
 
 /* woodpaul on board */
@@ -275,28 +148,6 @@ small {
     margin: 0;
 }
 
-.socialbuttons {
-    text-align: center;
-    margin: 0 0 -15px;
-}
-
-.socialbuttons iframe {
-    display: inline-block;
-}
-
-.socialbuttons .addthis_toolbox {
-    width: 420px;
-    display: inline-block;
-}
-
-.socialbuttons .share-github {
-    position: relative;
-    top: -5px;
-}
-
-.socialbuttons .addthis_button_facebook_like {
-    margin: 0 30px 0 0;
-}
 
 hr{
     background-color: transparent;
@@ -320,64 +171,5 @@ hr{
 
 code {
     padding: 1px 4px;
-}
-
-@media (min-width: 768px) {
-    .navbar-collapse {
-        float: left;
-    }
-
-    .dropdown:hover .dropdown-menu {
-        display: block;
-    }
-}
-
-@media (max-width: 1000px) {
-    .navbar .followus {
-        display: none;
-    }
-}
-
-@media (max-width: 767px) {
-    body {
-        padding-top: 110px;
-    }
-
-    .navbar-default .navbar-nav .open .dropdown-menu > li > a {
-        color: #fff;
-    }
-
-    .navbar-collapse {
-        background: #000 url(img/bg-menu.png) repeat-x left top; /*#377fa0;*/
-        color: #fff;
-    }
-
-    .navbar .nav > .active > a, .navbar .nav > .active > a:hover, .navbar .nav > .active > a:focus, .navbar .nav li.dropdown.active > .dropdown-toggle, .navbar .nav li.dropdown.open.active > .dropdown-toggle,
-    .navbar-default .navbar-nav .open .dropdown-menu > .active > a, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus,
-    .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover, .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
-        background: #d64513;
-        color: #fff;
-        height: auto;
-    }
-
-    .navbar-fixed-top > .container {
-        position: relative;
-    }
-
-    .navbar > .container .navbar-brand {
-        margin-left: 15px;
-    }
-
-    .navbar .socialbuttons {
-        position: absolute;
-        right: 100px;
-        top: 0;
-        width: 200px;
-        margin-top: 12px;
-    }
-
-    .navbar .addthis_toolbox {
-        display: none;
-    }
 }
 

--- a/demo/index-bs3.html
+++ b/demo/index-bs3.html
@@ -16,10 +16,9 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.8/css/all.css" integrity="sha384-3AB7yXWz4OeoZcPbieVW64vVXEwADiYyAEhwilzWsLw+9FgqpyjjStpPnpBO8o8S" crossorigin="anonymous">
 
 
-    <!-- BOOTSTRAP 4 -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">
-    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
-
+    <!-- BOOTSTRAP 3 -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.css" rel="stylesheet" type="text/css" media="all">
     <link href="../src/jquery.bootstrap-touchspin.css" rel="stylesheet" type="text/css" media="all">
@@ -108,12 +107,14 @@
        data-bts-button-up-class=&quot;btn btn-secondary&quot;
         /&gt;
 &lt;script&gt;
-    $(&quot;input[name='demo0']&quot;).TouchSpin();
+    $(&quot;input[name='demo0']&quot;).TouchSpin({
+    });
 &lt;/script&gt;
 </pre>
 
         <script>
-            $("input[name='demo0']").TouchSpin();
+            $("input[name='demo0']").TouchSpin({
+            });
         </script>
 
     </div>
@@ -381,19 +382,26 @@
     <div class="col-md-5">
 
         <label for="demo5">Button group:</label>
+        <a href="https://getbootstrap.com/docs/4.0/components/input-group/#button-addons" target="_blank">
+            little different for bootstrap v4
+        </a>
+
         <div class="input-group">
             <input id="demo5" type="text" class="form-control" name="demo5" value="50">
 
-            <div class="input-group-append">
-                <button type="button" class="btn btn-success">Action</button>
-                <button class="btn btn-info dropdown-toggle" type="button" data-toggle="dropdown">Dropdown</button>
-                <div class="dropdown-menu">
-                    <a class="dropdown-item" href="#">Action</a>
-                    <a class="dropdown-item" href="#">Another action</a>
-                    <a class="dropdown-item" href="#">Something else here</a>
-                    <div role="separator" class="dropdown-divider"></div>
-                    <a class="dropdown-item" href="#">Separated link</a>
-                </div>
+            <div class="input-group-btn">
+                <button type="button" class="btn btn-default">Action</button>
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    <span class="caret"></span>
+                    <span class="sr-only">Toggle Dropdown</span>
+                </button>
+                <ul class="dropdown-menu pull-right" role="menu">
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                    <li><a href="#">Something else here</a></li>
+                    <li class="divider"></li>
+                    <li><a href="#">Separated link</a></li>
+                </ul>
             </div>
         </div>
 
@@ -403,17 +411,19 @@
 <pre class="prettyprint">
 &lt;div class=&quot;input-group&quot;&gt;
     &lt;input id=&quot;demo5&quot; type=&quot;text&quot; class=&quot;form-control&quot; name=&quot;demo5&quot; value=&quot;50&quot;&gt;
-
-    &lt;div class=&quot;input-group-append&quot;&gt;
-        &lt;button type=&quot;button&quot; class=&quot;btn btn-success&quot;&gt;Action&lt;/button&gt;
-        &lt;button class=&quot;btn btn-info dropdown-toggle&quot; type=&quot;button&quot; data-toggle=&quot;dropdown&quot;&gt;Dropdown&lt;/button&gt;
-        &lt;div class=&quot;dropdown-menu&quot;&gt;
-            &lt;a class=&quot;dropdown-item&quot; href=&quot;#&quot;&gt;Action&lt;/a&gt;
-            &lt;a class=&quot;dropdown-item&quot; href=&quot;#&quot;&gt;Another action&lt;/a&gt;
-            &lt;a class=&quot;dropdown-item&quot; href=&quot;#&quot;&gt;Something else here&lt;/a&gt;
-            &lt;div role=&quot;separator&quot; class=&quot;dropdown-divider&quot;&gt;&lt;/div&gt;
-            &lt;a class=&quot;dropdown-item&quot; href=&quot;#&quot;&gt;Separated link&lt;/a&gt;
-        &lt;/div&gt;
+    &lt;div class=&quot;input-group-btn&quot;&gt;
+        &lt;button type=&quot;button&quot; class=&quot;btn btn-default&quot;&gt;Action&lt;/button&gt;
+        &lt;button type=&quot;button&quot; class=&quot;btn btn-default dropdown-toggle&quot; data-toggle=&quot;dropdown&quot;&gt;
+            &lt;span class=&quot;caret&quot;&gt;&lt;/span&gt;
+            &lt;span class=&quot;sr-only&quot;&gt;Toggle Dropdown&lt;/span&gt;
+        &lt;/button&gt;
+        &lt;ul class=&quot;dropdown-menu pull-right&quot; role=&quot;menu&quot;&gt;
+            &lt;li&gt;&lt;a href=&quot;#&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a href=&quot;#&quot;&gt;Another action&lt;/a&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a href=&quot;#&quot;&gt;Something else here&lt;/a&gt;&lt;/li&gt;
+            &lt;li class=&quot;divider&quot;&gt;&lt;/li&gt;
+            &lt;li&gt;&lt;a href=&quot;#&quot;&gt;Separated link&lt;/a&gt;&lt;/li&gt;
+        &lt;/ul&gt;
     &lt;/div&gt;
 &lt;/div&gt;
 &lt;script&gt;

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,23 +4,37 @@
     <meta charset="utf-8">
     <title>Bootstrap TouchSpin</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A mobile and touch friendly input spinner component for Bootstrap 3.">
+    <meta name="description" content="A mobile and touch friendly input spinner component for Bootstrap 3 & 4.">
     <meta name="author" content="István Ujj-Mészáros">
 
     <meta itemprop="name" content="Bootstrap Touchspin">
-    <meta itemprop="description" content="A mobile and touch friendly input spinner component for Bootstrap 3.">
+    <meta itemprop="description" content="A mobile and touch friendly input spinner component for Bootstrap 3 & 4.">
 
     <link rel="shortcut icon" href="favicon.ico">
 
-    <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
-    <link href="//cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.css" rel="stylesheet" type="text/css" media="all">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.8/css/all.css" integrity="sha384-3AB7yXWz4OeoZcPbieVW64vVXEwADiYyAEhwilzWsLw+9FgqpyjjStpPnpBO8o8S" crossorigin="anonymous">
+
+
+    <!-- BOOTSTRAP 3 -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
+
+    <!-- BOOTSTRAP 4 -->
+    <!--<link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">-->
+    <!--<script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.min.js"></script>-->
+
+
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.css" rel="stylesheet" type="text/css" media="all">
     <link href="../src/jquery.bootstrap-touchspin.css" rel="stylesheet" type="text/css" media="all">
     <link href="demo.css" rel="stylesheet" type="text/css" media="all">
-
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.js"></script>
     <script src="../src/jquery.bootstrap-touchspin.js"></script>
+
+
+
+
 </head>
 
 <body>
@@ -37,9 +51,13 @@
 </div>
 
 <p>
-    A mobile and touch friendly input spinner component for Bootstrap 3.<br>
+    A mobile and touch friendly input spinner component for Bootstrap 3 & 4.<br>
     It supports the mousewheel and the up/down keys.
 </p>
+
+<p>CSS file is necessary only if you are using vertical buttons functionality. In other cases plugin is using boostrap input-group component.</p>
+
+<p>All HTML examples are for bootstrap v3. For v4 visit bootstrap <a href="https://getbootstrap.com/docs/4.0/components/forms/" target="_blank">documentation</a> (small differences). Plugin usage is identical for both versions and uses same .js and .css file.</p>
 
 <h2>Examples</h2>
 
@@ -66,8 +84,8 @@
             data-bts-boostat="10"
             data-bts-max-boosted-step="false"
             data-bts-mousewheel="true"
-            data-bts-button-down-class="btn btn-default"
-            data-bts-button-up-class="btn btn-default"
+            data-bts-button-down-class="btn btn-success"
+            data-bts-button-up-class="btn btn-success"
             >
     </div>
 
@@ -93,8 +111,8 @@
        data-bts-boostat=&quot;10&quot;
        data-bts-max-boosted-step=&quot;false&quot;
        data-bts-mousewheel=&quot;true&quot;
-       data-bts-button-down-class=&quot;btn btn-default&quot;
-       data-bts-button-up-class=&quot;btn btn-default&quot;
+       data-bts-button-down-class=&quot;btn btn-secondary&quot;
+       data-bts-button-up-class=&quot;btn btn-secondary&quot;
         /&gt;
 &lt;script&gt;
     $(&quot;input[name='demo0']&quot;).TouchSpin({
@@ -110,9 +128,10 @@
     </div>
 </div>
 
-<div class="row">
+
+    <div class="row">
     <div class="col-md-5">
-        <label for="demo_vertical">Vertical button alignment:</label> <input id="demo_vertical" type="text" value="" name="demo_vertical">
+        <label for="demo_vertical">Vertical button alignment (large):</label> <input id="demo_vertical" type="text" value="" name="demo_vertical" class="input-lg">
     </div>
 
     <div class="col-md-7">
@@ -136,7 +155,7 @@
 
 <div class="row">
     <div class="col-md-5">
-        <label for="demo_vertical2">Vertical buttons with custom icons:</label> <input id="demo_vertical2" type="text" value="" name="demo_vertical2">
+        <label for="demo_vertical2">Vertical buttons with custom icons (small):</label> <input id="demo_vertical2" type="text" value="" name="demo_vertical2" class="input-sm">
     </div>
 
     <div class="col-md-7">
@@ -145,8 +164,8 @@
 &lt;script&gt;
     $(&quot;input[name='demo_vertical2']&quot;).TouchSpin({
       verticalbuttons: true,
-      verticalupclass: 'glyphicon glyphicon-plus',
-      verticaldownclass: 'glyphicon glyphicon-minus'
+      verticalup: '&lt;i class=&quot;fas fa-caret-up&quot;&gt;&lt;/i&gt;',
+      verticaldown: '&lt;i class=&quot;fas fa-caret-down&quot;&gt;&lt;/i&gt;'
     });
 &lt;/script&gt;
 </pre>
@@ -154,8 +173,8 @@
         <script>
             $("input[name='demo_vertical2']").TouchSpin({
               verticalbuttons: true,
-              verticalupclass: 'glyphicon glyphicon-plus',
-              verticaldownclass: 'glyphicon glyphicon-minus'
+              verticalup: '<i class="fas fa-caret-up"></i>',
+              verticaldown: '<i class="fas fa-caret-down"></i>'
             });
         </script>
 
@@ -164,7 +183,7 @@
 
 <div class="row">
     <div class="col-md-5">
-        <label for="demo1">Example with postfix (large):</label> <input id="demo1" type="text" value="55" name="demo1">
+        <label for="demo1">Example with postfix:</label> <input id="demo1" type="text" value="55" name="demo1">
     </div>
 
     <div class="col-md-7">
@@ -266,23 +285,23 @@
     </p>
 
     <div class="col-md-5">
-        <label for="demo3_21">Value attribute is not set
+        <label for="demo3_21">Value attribute is not set (Big)
             <small>(applying settings.initval)</small>
-            :</label> <input id="demo3_21" type="text" value="" name="demo3_21">
-        <label for="demo3_22">Value is set explicitly to 33
+            :</label> <input id="demo3_21" type="text" class="input-lg" value="" name="demo3_21">
+        <label for="demo3_22">Value is set explicitly to 33 (Small)
             <small>(skipping settings.initval)</small>
-            :</label> <input id="demo3_22" type="text" value="33" name="demo3_22">
+            :</label> <input id="demo3_22" type="text" class="input-sm" value="33" name="demo3_22">
     </div>
 
     <div class="col-md-7">
 <pre class="prettyprint">
-&lt;input id=&quot;demo3_21&quot; type=&quot;text&quot; value=&quot;&quot; name=&quot;demo3_21&quot;&gt;
+&lt;input id=&quot;demo3_21&quot; type=&quot;text&quot; class=&quot;input-lg&quot; value=&quot;&quot; name=&quot;demo3_21&quot;&gt;
 &lt;script&gt;
     $(&quot;input[name='demo3_21']&quot;).TouchSpin({
         initval: 40
     });
 &lt;/script&gt;
-&lt;input id=&quot;demo3_22&quot; type=&quot;text&quot; value=&quot;33&quot; name=&quot;demo3_22&quot;&gt;
+&lt;input id=&quot;demo3_22&quot; type=&quot;text&quot; class=&quot;input-sm&quot; value=&quot;33&quot; name=&quot;demo3_22&quot;&gt;
 &lt;script&gt;
     $(&quot;input[name='demo3_22']&quot;).TouchSpin({
         initval: 40
@@ -320,7 +339,7 @@
 &lt;script&gt;
     $(&quot;input[name='demo4']&quot;).TouchSpin({
         postfix: &quot;a button&quot;,
-        postfix_extraclass: &quot;btn btn-default&quot;
+        postfix_extraclass: &quot;btn btn-primary&quot;
     });
 &lt;/script&gt;
 </pre>
@@ -328,7 +347,7 @@
         <script>
             $("input[name='demo4']").TouchSpin({
                 postfix: "a button",
-                postfix_extraclass: "btn btn-default"
+                postfix_extraclass: "btn btn-primary"
             });
         </script>
 
@@ -352,7 +371,7 @@
 &lt;script&gt;
     $(&quot;input[name='demo4_2']&quot;).TouchSpin({
         postfix: &quot;a button&quot;,
-        postfix_extraclass: &quot;btn btn-default&quot;
+        postfix_extraclass: &quot;btn btn-primary&quot;
     });
 &lt;/script&gt;
 </pre>
@@ -360,7 +379,7 @@
         <script>
             $("input[name='demo4_2']").TouchSpin({
                 postfix: "a button",
-                postfix_extraclass: "btn btn-default"
+                postfix_extraclass: "btn btn-primary"
             });
         </script>
 
@@ -371,6 +390,9 @@
     <div class="col-md-5">
 
         <label for="demo5">Button group:</label>
+        <a href="https://getbootstrap.com/docs/4.0/components/input-group/#button-addons" target="_blank">
+            little different for bootstrap v4
+        </a>
 
         <div class="input-group">
             <input id="demo5" type="text" class="form-control" name="demo5" value="50">
@@ -591,13 +613,23 @@ $(&quot;input[name='demo7']&quot;).TouchSpin({
         <td>Enables the traditional up/down buttons.</td>
     </tr>
     <tr>
+        <td><code>verticalup</code></td>
+        <td><code>+</code></td>
+        <td>Content of the up button with vertical buttons mode enabled.</td>
+    </tr>
+    <tr>
+        <td><code>verticaldown</code></td>
+        <td><code>-</code></td>
+        <td>Content of the down button with vertical buttons mode enabled.</td>
+    </tr>
+    <tr>
         <td><code>verticalupclass</code></td>
-        <td><code>'glyphicon glyphicon-chevron-up'</code></td>
+        <td><code>""</code></td>
         <td>Class of the up button with vertical buttons mode enabled.</td>
     </tr>
     <tr>
         <td><code>verticaldownclass</code></td>
-        <td><code>'glyphicon glyphicon-chevron-down'</code></td>
+        <td><code>""</code></td>
         <td>Class of the down button with vertical buttons mode enabled.</td>
     </tr>
     <tr>
@@ -642,12 +674,12 @@ $(&quot;input[name='demo7']&quot;).TouchSpin({
     </tr>
     <tr>
         <td><code>buttondown_class</code></td>
-        <td><code>'btn btn-default'</code></td>
+        <td><code>'btn btn-primary'</code></td>
         <td>Class(es) of down button.</td>
     </tr>
     <tr>
         <td><code>buttonup_class</code></td>
-        <td><code>'btn btn-default'</code></td>
+        <td><code>'btn btn-primary'</code></td>
         <td>Class(es) of up button.</td>
     </tr>
     <tr>
@@ -776,3 +808,6 @@ $(&quot;input[name='demo7']&quot;).TouchSpin({
 <script>
     prettyPrint();
 </script>
+
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -112,7 +112,7 @@
 
 <div class="row">
     <div class="col-md-5">
-        <label for="demo_vertical">Vertical button alignment:</label> <input id="demo3" type="text" value="" name="demo_vertical">
+        <label for="demo_vertical">Vertical button alignment:</label> <input id="demo_vertical" type="text" value="" name="demo_vertical">
     </div>
 
     <div class="col-md-7">
@@ -136,7 +136,7 @@
 
 <div class="row">
     <div class="col-md-5">
-        <label for="demo_vertical2">Vertical buttons with custom icons:</label> <input id="demo3" type="text" value="" name="demo_vertical2">
+        <label for="demo_vertical2">Vertical buttons with custom icons:</label> <input id="demo_vertical2" type="text" value="" name="demo_vertical2">
     </div>
 
     <div class="col-md-7">
@@ -337,7 +337,7 @@
 
 <div class="row">
     <div class="col-md-5">
-        <label for="demo4">Button postfix (large):</label>
+        <label for="demo4_2">Button postfix (large):</label>
 
         <div class="input-group input-group-lg">
             <input id="demo4_2" type="text" value="" name="demo4_2" class="form-control input-lg">
@@ -474,19 +474,19 @@ $(&quot;input[name='demo7']&quot;).TouchSpin({
     </div>
 </div>
 
-<h3>Event demo</h3>
 
 <div class="row">
     <div class="col-md-3">
-        <input id="demo7" type="text" value="50" name="demo7">
+        <label for="demo8">Event demo:</label>
+        <input id="demo8" type="text" value="50" name="demo8">
     </div>
     <div class="col-md-9">
-        <pre id="demo7textarea" style="height:200px;overflow:auto;"></pre>
+        <pre id="demo8textarea" style="height:200px;overflow:auto;"></pre>
     </div>
 
     <script>
-        var i = $("input[name='demo7']"),
-                demoarea = $("#demo7textarea"),
+        var i = $("input[name='demo8']"),
+                demoarea = $("#demo8textarea"),
                 text = "";
 
         function writeLine(line) {

--- a/dist/jquery.bootstrap-touchspin.css
+++ b/dist/jquery.bootstrap-touchspin.css
@@ -1,45 +1,38 @@
 /*
- *  Bootstrap TouchSpin - v3.1.2
- *  A mobile and touch friendly input spinner component for Bootstrap 3.
+ *  Bootstrap TouchSpin - v4.0.0
+ *  A mobile and touch friendly input spinner component for Bootstrap 3 & 4.
  *  http://www.virtuosoft.eu/code/bootstrap-touchspin/
  *
  *  Made by István Ujj-Mészáros
  *  Under Apache License v2.0 License
  */
+/* This CSS file is unnecessary if you are not using vertical buttons functionality */
 
 .bootstrap-touchspin .input-group-btn-vertical {
-  position: relative;
-  white-space: nowrap;
-  width: 1%;
-  vertical-align: middle;
-  display: table-cell;
+  position: absolute;
+  right: 0;
+  height: 100%;
+  z-index: 11;
 }
 
 .bootstrap-touchspin .input-group-btn-vertical > .btn {
-  display: block;
-  float: none;
-  width: 100%;
-  max-width: 100%;
-  padding: 8px 10px;
-  margin-left: -1px;
-  position: relative;
+  position: absolute;
+  right: 0;
+  height: 50%;
+  padding: 0;
+  width: 2em;
+  text-align: center;
+  line-height: 1;
 }
 
 .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-up {
-  border-radius: 0;
-  border-top-right-radius: 4px;
+  border-radius: 0 4px 0 0;
+  top: 0;
 }
 
 .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-down {
-  margin-top: -2px;
-  border-radius: 0;
-  border-bottom-right-radius: 4px;
+  border-radius: 0 0 4px 0;
+  bottom: 0;
 }
 
-.bootstrap-touchspin .input-group-btn-vertical i {
-  position: absolute;
-  top: 3px;
-  left: 5px;
-  font-size: 9px;
-  font-weight: normal;
-}
+

--- a/dist/jquery.bootstrap-touchspin.js
+++ b/dist/jquery.bootstrap-touchspin.js
@@ -243,7 +243,13 @@
         var html;
 
         var inputGroupSize = '';
-        if (originalinput.hasClass('input-sm')) inputGroupSize = 'input-group-sm';
+        if (originalinput.hasClass('input-sm')) {
+          inputGroupSize = 'input-group-sm';
+        }
+
+        if (originalinput.hasClass('input-lg')) {
+            inputGroupSize = 'input-group-lg';
+        }
 
         if (settings.verticalbuttons) {
           html = '<div class="input-group '  + inputGroupSize +  ' bootstrap-touchspin"><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix input-group-prepend"><span class="input-group-text">' + settings.postfix + '</span></span><span class="input-group-btn-vertical"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-up ' + settings.verticalupclass + '" type="button">' + settings.verticalup + '</button><button class="' + settings.buttonup_class + ' bootstrap-touchspin-down ' + settings.verticaldownclass + '" type="button">' + settings.verticaldown + '</button></span></div>';

--- a/dist/jquery.bootstrap-touchspin.js
+++ b/dist/jquery.bootstrap-touchspin.js
@@ -1,6 +1,6 @@
 /*
- *  Bootstrap TouchSpin - v3.1.2
- *  A mobile and touch friendly input spinner component for Bootstrap 3.
+ *  Bootstrap TouchSpin - v4.0.0
+ *  A mobile and touch friendly input spinner component for Bootstrap 3 & 4.
  *  http://www.virtuosoft.eu/code/bootstrap-touchspin/
  *
  *  Made by István Ujj-Mészáros
@@ -50,8 +50,10 @@
       forcestepdivisibility: 'round', // none | floor | round | ceil
       stepintervaldelay: 500,
       verticalbuttons: false,
-      verticalupclass: 'glyphicon glyphicon-chevron-up',
-      verticaldownclass: 'glyphicon glyphicon-chevron-down',
+      verticalup: '+',
+      verticaldown: '-',
+      verticalupclass: '',
+      verticaldownclass: '',
       prefix: '',
       postfix: '',
       prefix_extraclass: '',
@@ -60,8 +62,8 @@
       boostat: 10,
       maxboostedstep: false,
       mousewheel: true,
-      buttondown_class: 'btn btn-default',
-      buttonup_class: 'btn btn-default',
+      buttondown_class: 'btn btn-primary',
+      buttonup_class: 'btn btn-primary',
       buttondown_txt: '-',
       buttonup_txt: '+'
     };
@@ -107,6 +109,7 @@
           upDelayTimeout,
           spincount = 0,
           spinning = false;
+
 
       init();
 
@@ -209,24 +212,24 @@
 
         var downhtml,
             uphtml,
-            prefixhtml = '<span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span>',
-            postfixhtml = '<span class="input-group-addon bootstrap-touchspin-postfix">' + settings.postfix + '</span>';
+            prefixhtml = '<span class="input-group-addon bootstrap-touchspin-prefix input-group-prepend"><span class="input-group-text">' + settings.prefix + '</span></span>',
+            postfixhtml = '<span class="input-group-addon bootstrap-touchspin-postfix input-group-append"><span class="input-group-text">' + settings.postfix + '</span></span>';
 
-        if (prev.hasClass('input-group-btn')) {
+        if (prev.hasClass('input-group-btn') || prev.hasClass('input-group-prepend')) {
           downhtml = '<button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button>';
           prev.append(downhtml);
         }
         else {
-          downhtml = '<span class="input-group-btn"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span>';
+          downhtml = '<span class="input-group-btn input-group-prepend"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span>';
           $(downhtml).insertBefore(originalinput);
         }
 
-        if (next.hasClass('input-group-btn')) {
+        if (next.hasClass('input-group-btn') || next.hasClass('input-group-append') ) {
           uphtml = '<button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button>';
           next.prepend(uphtml);
         }
         else {
-          uphtml = '<span class="input-group-btn"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span>';
+          uphtml = '<span class="input-group-btn input-group-append"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span>';
           $(uphtml).insertAfter(originalinput);
         }
 
@@ -239,11 +242,14 @@
       function _buildInputGroup() {
         var html;
 
+        var inputGroupSize = '';
+        if (originalinput.hasClass('input-sm')) inputGroupSize = 'input-group-sm';
+
         if (settings.verticalbuttons) {
-          html = '<div class="input-group bootstrap-touchspin"><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix">' + settings.postfix + '</span><span class="input-group-btn-vertical"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-up" type="button"><i class="' + settings.verticalupclass + '"></i></button><button class="' + settings.buttonup_class + ' bootstrap-touchspin-down" type="button"><i class="' + settings.verticaldownclass + '"></i></button></span></div>';
+          html = '<div class="input-group '  + inputGroupSize +  ' bootstrap-touchspin"><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix input-group-prepend"><span class="input-group-text">' + settings.postfix + '</span></span><span class="input-group-btn-vertical"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-up ' + settings.verticalupclass + '" type="button">' + settings.verticalup + '</button><button class="' + settings.buttonup_class + ' bootstrap-touchspin-down ' + settings.verticaldownclass + '" type="button">' + settings.verticaldown + '</button></span></div>';
         }
         else {
-          html = '<div class="input-group bootstrap-touchspin"><span class="input-group-btn"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix">' + settings.postfix + '</span><span class="input-group-btn"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span></div>';
+          html = '<div class="input-group bootstrap-touchspin"><span class="input-group-btn input-group-prepend"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span><span class="input-group-addon bootstrap-touchspin-prefix input-group-prepend"><span class="input-group-text">' + settings.prefix + '</span></span><span class="input-group-addon bootstrap-touchspin-postfix input-group-append"><span class="input-group-text">' + settings.postfix + '</span></span><span class="input-group-btn input-group-append"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span></div>';
         }
 
         container = $(html).insertBefore(originalinput);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-touchspin",
   "title": "Bootstrap Touchspin",
-  "description": "A mobile and touch friendly input spinner component for Bootstrap 3.",
+  "description": "A mobile and touch friendly input spinner component for Bootstrap 3 & 4.",
   "author": {
     "name": "István Ujj-Mészáros",
     "url": "https://github.com/istvan-ujjmeszaros"
@@ -31,6 +31,10 @@
     {
       "name": "amid2887",
       "url": "https://github.com/amid2887"
+    },
+    {
+      "name": "lukchojnicki",
+      "url": "https://github.com/lukchojnicki"
     }
   ],
   "repository": {
@@ -38,7 +42,7 @@
     "url": "http://github.com/istvan-ujjmeszaros/bootstrap-touchspin.git"
   },
   "homepage": "http://www.virtuosoft.eu/code/bootstrap-touchspin/",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.13",
@@ -48,6 +52,7 @@
     "grunt-contrib-cssmin": "~0.9.0"
   },
   "scripts": {
-    "test": "grunt travis --verbose"
+    "test": "grunt travis --verbose",
+    "concat": "grunt concat"
   }
 }

--- a/src/jquery.bootstrap-touchspin.css
+++ b/src/jquery.bootstrap-touchspin.css
@@ -1,37 +1,30 @@
+/* This CSS file is unnecessary if you are not using vertical buttons functionality */
 
 .bootstrap-touchspin .input-group-btn-vertical {
-  position: relative;
-  white-space: nowrap;
-  width: 1%;
-  vertical-align: middle;
-  display: table-cell;
+  position: absolute;
+  right: 0;
+  height: 100%;
+  z-index: 11;
 }
 
 .bootstrap-touchspin .input-group-btn-vertical > .btn {
-  display: block;
-  float: none;
-  width: 100%;
-  max-width: 100%;
-  padding: 8px 10px;
-  margin-left: -1px;
-  position: relative;
+  position: absolute;
+  right: 0;
+  height: 50%;
+  padding: 0;
+  width: 2em;
+  text-align: center;
+  line-height: 1;
 }
 
 .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-up {
-  border-radius: 0;
-  border-top-right-radius: 4px;
+  border-radius: 0 4px 0 0;
+  top: 0;
 }
 
 .bootstrap-touchspin .input-group-btn-vertical .bootstrap-touchspin-down {
-  margin-top: -2px;
-  border-radius: 0;
-  border-bottom-right-radius: 4px;
+  border-radius: 0 0 4px 0;
+  bottom: 0;
 }
 
-.bootstrap-touchspin .input-group-btn-vertical i {
-  position: absolute;
-  top: 3px;
-  left: 5px;
-  font-size: 9px;
-  font-weight: normal;
-}
+

--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -42,8 +42,10 @@
       forcestepdivisibility: 'round', // none | floor | round | ceil
       stepintervaldelay: 500,
       verticalbuttons: false,
-      verticalupclass: 'glyphicon glyphicon-chevron-up',
-      verticaldownclass: 'glyphicon glyphicon-chevron-down',
+      verticalup: '+',
+      verticaldown: '-',
+      verticalupclass: '',
+      verticaldownclass: '',
       prefix: '',
       postfix: '',
       prefix_extraclass: '',
@@ -52,8 +54,8 @@
       boostat: 10,
       maxboostedstep: false,
       mousewheel: true,
-      buttondown_class: 'btn btn-default',
-      buttonup_class: 'btn btn-default',
+      buttondown_class: 'btn btn-primary',
+      buttonup_class: 'btn btn-primary',
       buttondown_txt: '-',
       buttonup_txt: '+'
     };
@@ -99,6 +101,7 @@
           upDelayTimeout,
           spincount = 0,
           spinning = false;
+
 
       init();
 
@@ -201,24 +204,24 @@
 
         var downhtml,
             uphtml,
-            prefixhtml = '<span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span>',
-            postfixhtml = '<span class="input-group-addon bootstrap-touchspin-postfix">' + settings.postfix + '</span>';
+            prefixhtml = '<span class="input-group-addon bootstrap-touchspin-prefix input-group-prepend"><span class="input-group-text">' + settings.prefix + '</span></span>',
+            postfixhtml = '<span class="input-group-addon bootstrap-touchspin-postfix input-group-append"><span class="input-group-text">' + settings.postfix + '</span></span>';
 
-        if (prev.hasClass('input-group-btn')) {
+        if (prev.hasClass('input-group-btn') || prev.hasClass('input-group-prepend')) {
           downhtml = '<button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button>';
           prev.append(downhtml);
         }
         else {
-          downhtml = '<span class="input-group-btn"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span>';
+          downhtml = '<span class="input-group-btn input-group-prepend"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span>';
           $(downhtml).insertBefore(originalinput);
         }
 
-        if (next.hasClass('input-group-btn')) {
+        if (next.hasClass('input-group-btn') || next.hasClass('input-group-append') ) {
           uphtml = '<button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button>';
           next.prepend(uphtml);
         }
         else {
-          uphtml = '<span class="input-group-btn"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span>';
+          uphtml = '<span class="input-group-btn input-group-append"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span>';
           $(uphtml).insertAfter(originalinput);
         }
 
@@ -231,11 +234,14 @@
       function _buildInputGroup() {
         var html;
 
+        var inputGroupSize = '';
+        if (originalinput.hasClass('input-sm')) inputGroupSize = 'input-group-sm';
+
         if (settings.verticalbuttons) {
-          html = '<div class="input-group bootstrap-touchspin"><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix">' + settings.postfix + '</span><span class="input-group-btn-vertical"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-up" type="button"><i class="' + settings.verticalupclass + '"></i></button><button class="' + settings.buttonup_class + ' bootstrap-touchspin-down" type="button"><i class="' + settings.verticaldownclass + '"></i></button></span></div>';
+          html = '<div class="input-group '  + inputGroupSize +  ' bootstrap-touchspin"><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix input-group-prepend"><span class="input-group-text">' + settings.postfix + '</span></span><span class="input-group-btn-vertical"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-up ' + settings.verticalupclass + '" type="button">' + settings.verticalup + '</button><button class="' + settings.buttonup_class + ' bootstrap-touchspin-down ' + settings.verticaldownclass + '" type="button">' + settings.verticaldown + '</button></span></div>';
         }
         else {
-          html = '<div class="input-group bootstrap-touchspin"><span class="input-group-btn"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix">' + settings.postfix + '</span><span class="input-group-btn"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span></div>';
+          html = '<div class="input-group bootstrap-touchspin"><span class="input-group-btn input-group-prepend"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-down" type="button">' + settings.buttondown_txt + '</button></span><span class="input-group-addon bootstrap-touchspin-prefix input-group-prepend"><span class="input-group-text">' + settings.prefix + '</span></span><span class="input-group-addon bootstrap-touchspin-postfix input-group-append"><span class="input-group-text">' + settings.postfix + '</span></span><span class="input-group-btn input-group-append"><button class="' + settings.buttonup_class + ' bootstrap-touchspin-up" type="button">' + settings.buttonup_txt + '</button></span></div>';
         }
 
         container = $(html).insertBefore(originalinput);

--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -235,7 +235,13 @@
         var html;
 
         var inputGroupSize = '';
-        if (originalinput.hasClass('input-sm')) inputGroupSize = 'input-group-sm';
+        if (originalinput.hasClass('input-sm')) {
+          inputGroupSize = 'input-group-sm';
+        }
+
+        if (originalinput.hasClass('input-lg')) {
+            inputGroupSize = 'input-group-lg';
+        }
 
         if (settings.verticalbuttons) {
           html = '<div class="input-group '  + inputGroupSize +  ' bootstrap-touchspin"><span class="input-group-addon bootstrap-touchspin-prefix">' + settings.prefix + '</span><span class="input-group-addon bootstrap-touchspin-postfix input-group-prepend"><span class="input-group-text">' + settings.postfix + '</span></span><span class="input-group-btn-vertical"><button class="' + settings.buttondown_class + ' bootstrap-touchspin-up ' + settings.verticalupclass + '" type="button">' + settings.verticalup + '</button><button class="' + settings.buttonup_class + ' bootstrap-touchspin-down ' + settings.verticaldownclass + '" type="button">' + settings.verticaldown + '</button></span></div>';


### PR DESCRIPTION
* Works with bootstrap 4 keeping backward compatibility (no additional options required). 
* Some fixes in demo (id duplicates and some other warnings, removed a lot of unnecessary code in demo.css).
* Glyphicons removed (not available in bs4) and replaced by simple "+", "-". In demo fontawesome as example.
* New css for vertical buttons (table to absolute) so it can works in bs3 and bs4 with same code. Should be better tested, but in demo works ok. 
* Added verticalup and verticaldown attrubutes as button text. verticalupclass and verticaldownclass now is used as button class, not "i" icon class. This way poeple can pass not only icon as it was before but also normal text.
* Add 4.0.0 version tag in all files (ready to npm and others)