### PR TITLE
Add parameter 'firstclickvalueifempty' and set value to midpoint if not set

### DIFF
--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -29,6 +29,7 @@
       max: 100, // If null, there is no maximum enforced
       initval: '',
       replacementval: '',
+      firstclickvalueifempty: null,
       step: 1,
       decimals: 0,
       stepinterval: 100,
@@ -64,6 +65,7 @@
       max: 'max',
       initval: 'init-val',
       replacementval: 'replacement-val',
+      firstclickvalueifempty: 'first-click-value-if-empty',
       step: 'step',
       decimals: 'decimals',
       stepinterval: 'step-interval',
@@ -613,18 +615,28 @@
         }
       }
 
+      function valueIfIsNaN() {
+        if(typeof(settings.firstclickvalueifempty) === 'number') {
+          return settings.firstclickvalueifempty;
+        } else {
+          return (settings.min + settings.max) / 2;
+        }
+      }
+
       function upOnce() {
         _checkValue();
 
         value = parseFloat(settings.callback_before_calculation(elements.input.val()));
+
+        var initvalue = value;
+        var boostedstep;
+
         if (isNaN(value)) {
-          value = 0;
-        }
-
-        var initvalue = value,
+          value = valueIfIsNaN();
+        } else {
           boostedstep = _getBoostedStep();
-
-        value = value + boostedstep;
+          value = value + boostedstep;
+        }
 
         if ((settings.max !== null) && (value > settings.max)) {
           value = settings.max;
@@ -643,14 +655,16 @@
         _checkValue();
 
         value = parseFloat(settings.callback_before_calculation(elements.input.val()));
+
+        var initvalue = value;
+        var boostedstep;
+
         if (isNaN(value)) {
-          value = 0;
-        }
-
-        var initvalue = value,
+          value = valueIfIsNaN();
+        } else {
           boostedstep = _getBoostedStep();
-
-        value = value - boostedstep;
+          value = value - boostedstep;
+        }
 
         if ((settings.min !== null) && (value < settings.min)) {
           value = settings.min;


### PR DESCRIPTION
When an input is set up without an initial value, the first click increases or decreases the value from zero by the  _getBoostedStep amount.

If you are tracking with a min..max range of say 1000...2000 in steps of 10, and you click [+], you therefore get a first initial value of 10. The next click it seems to fix itself and you get 1010.

This PR changes this behaviour so that your first click on an empty value either:
a) allows you to set a firstclickvalueifempty
b) sets to half way between min and max

I guess more work could be done on this, but I found it useful enough to think a PR would be worthwhile.