### PR TITLE
initial values get parsed by the callback before being interpreted as a number

### DIFF
--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -221,6 +221,8 @@
           parentelement = originalinput.parent();
 
         if (initval !== '') {
+	  // initval may not be parsable as a number (callback_after_calculation() may decorate it so it cant be parsed).  Use the callbacks if provided.
+	  initval = settings.callback_before_calculation(initval);
           initval = settings.callback_after_calculation(Number(initval).toFixed(settings.decimals));
         }
 
@@ -354,7 +356,9 @@
 
         originalinput.on('blur.touchspin', function() {
           _checkValue();
-          originalinput.val(settings.callback_after_calculation(originalinput.val()));
+	  // initval may not be parsable as a number (callback_after_calculation() may decorate it so it cant be parsed).  Use the callbacks if provided.
+	  var value = settings.callback_before_calculation(originalinput.val());
+          originalinput.val(settings.callback_after_calculation(value));
         });
 
         elements.down.on('keydown', function(ev) {

--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -159,7 +159,13 @@
           var attrName = 'bts-' + value + '';
           if (originalinput.is('[data-' + attrName + ']')) {
             data[key] = originalinput.data(attrName);
-          }
+          } else if (key == "min") {
+	      data[key]=originalinput.attr(key);
+          } else if (key == "max") {
+	      data[key]=originalinput.attr(key);
+          } else if (key == "step") {
+	      data[key]=originalinput.attr(key);
+	  }
         });
         return data;
       }
@@ -739,3 +745,4 @@
   };
 
 }));
+

--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -159,11 +159,11 @@
           var attrName = 'bts-' + value + '';
           if (originalinput.is('[data-' + attrName + ']')) {
             data[key] = originalinput.data(attrName);
-          } else if (key == "min") {
+          } else if (key === 'min') {
 	      data[key]=originalinput.attr(key);
-          } else if (key == "max") {
+          } else if (key === 'max') {
 	      data[key]=originalinput.attr(key);
-          } else if (key == "step") {
+          } else if (key === 'step') {
 	      data[key]=originalinput.attr(key);
 	  }
         });


### PR DESCRIPTION
Fixes #110 -- initial values get parsed by the callback before being interpreted as a number.
initval may not be parsable as a number (callback_after_calculation() may decorate it so it cant be parsed).  Use the callbacks if provided.