### PR TITLE
fix #110 init values parsed by callbacks

### DIFF
--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -215,6 +215,8 @@
           parentelement = originalinput.parent();
 
         if (initval !== '') {
+	  // initval may not be parsable as a number (callback_after_calculation() may decorate it so it cant be parsed).  Use the callbacks if provided.
+	  initval = settings.callback_before_calculation(initval);
           initval = settings.callback_after_calculation(Number(initval).toFixed(settings.decimals));
         }
 
@@ -348,7 +350,9 @@
 
         originalinput.on('blur.touchspin', function() {
           _checkValue();
-          originalinput.val(settings.callback_after_calculation(originalinput.val()));
+	  // initval may not be parsable as a number (callback_after_calculation() may decorate it so it cant be parsed).  Use the callbacks if provided.
+	  var value = settings.callback_before_calculation(originalinput.val());
+          originalinput.val(settings.callback_after_calculation(value));
         });
 
         elements.down.on('keydown', function(ev) {
@@ -739,3 +743,4 @@
   };
 
 }));
+

--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -596,7 +596,7 @@
         returnval = _forcestepdivisibility(returnval);
 
         if (Number(val).toString() !== returnval.toString()) {
-          originalinput.val(returnval);
+          originalinput.val(settings.callback_after_calculation(returnval));
           originalinput.trigger('change');
         }
       }


### PR DESCRIPTION
initval may not be parsable as a number (callback_after_calculation() may decorate it so it cant be parsed).  Use the callbacks if provided.