### PR TITLE
Fixing change events

### DIFF
--- a/.github/workflows/check-dist-folder-integrity.yml
+++ b/.github/workflows/check-dist-folder-integrity.yml
@@ -1,0 +1,39 @@
+name: run-tests
+run-name: Run tests
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check dist folder integrity
+        run: npm run check-build-integrity

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,6 +31,3 @@ jobs:
 
       - name: Run tests
         run: npm test
-
-      - name: Check dist folder integrity
-        run: npm run check-build-integrity

--- a/__tests__/basicOperations.test.ts
+++ b/__tests__/basicOperations.test.ts
@@ -4,7 +4,7 @@ import {page} from './helpers/jestPuppeteerServerSetup';
 describe('Core functionality', () => {
 
   it('should have a TouchSpin button', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     const button = await page.$(selector + ' + .input-group-btn > .bootstrap-touchspin-up');
 
@@ -12,7 +12,7 @@ describe('Core functionality', () => {
   });
 
   it('should increase value by 1 when clicking the + button', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     // We have to use the mousedown and mouseup events because the plugin is not handling the click event.
     await touchspinHelpers.touchspinClickUp(page, selector);
@@ -21,7 +21,7 @@ describe('Core functionality', () => {
   });
 
   it('should not increase value when clicking the + button with a disabled input', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     await touchspinHelpers.setInputAttr(page, selector, 'disabled', true);
 
@@ -32,7 +32,7 @@ describe('Core functionality', () => {
   });
 
   it('should not increase value when clicking the + button with a readonly input', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     await touchspinHelpers.setInputAttr(page, selector, 'readonly', true);
 
@@ -43,7 +43,7 @@ describe('Core functionality', () => {
   });
 
   it('setting the input disabled should disable the touchspin buttons', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     await touchspinHelpers.setInputAttr(page, selector, 'disabled', true);
 
@@ -54,7 +54,7 @@ describe('Core functionality', () => {
   });
 
   it('setting the input readonly should disable the touchspin buttons', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     await touchspinHelpers.setInputAttr(page, selector, 'readonly', true);
 
@@ -65,7 +65,7 @@ describe('Core functionality', () => {
   });
 
   it('disabled input should initialize with disabled touchspin buttons', async () => {
-    const selector: string = '#testinput3';
+    const selector: string = '#testinput_disabled';
 
     // We have to use the mousedown and mouseup events because the plugin is not handling the click event.
     await touchspinHelpers.touchspinClickUp(page, selector);
@@ -74,7 +74,7 @@ describe('Core functionality', () => {
   });
 
   it('readonly input should initialize with disabled touchspin buttons', async () => {
-    const selector: string = '#testinput4';
+    const selector: string = '#testinput_readonly';
 
     // We have to use the mousedown and mouseup events because the plugin is not handling the click event.
     await touchspinHelpers.touchspinClickUp(page, selector);

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -4,7 +4,7 @@ import {page} from './helpers/jestPuppeteerServerSetup';
 describe('Events', () => {
 
   it('should increase value by 1 when clicking the + button', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     // We have to use the mousedown and mouseup events because the plugin is not handling the click event.
     await touchspinHelpers.touchspinClickUp(page, selector);
@@ -13,7 +13,7 @@ describe('Events', () => {
   });
 
   it('should fire the change event only once when updating the value', async () => {
-    const selector: string = '#testinput1';
+    const selector: string = '#testinput_default';
 
     // Trigger the TouchSpin button
     await touchspinHelpers.touchspinClickUp(page, selector);
@@ -24,8 +24,8 @@ describe('Events', () => {
     expect(await touchspinHelpers.changeEventCounter(page)).toBe(1);
   });
 
-  it('should fire the change event only once when updating the value using the keyboard and pressing TAB', async () => {
-    const selector: string = '#testinput1';
+  it('should fire the change event exactly once when entering a proper value and pressing TAB', async () => {
+    const selector: string = '#testinput_default';
 
     // Focus on the input element
     await page.focus(selector);
@@ -34,7 +34,7 @@ describe('Events', () => {
     await page.click(selector, { clickCount: 2 });
 
     // Type a new value
-    await page.keyboard.type('45');
+    await page.keyboard.type('67');
 
     // Press the TAB key to move out of the input field
     await page.keyboard.press('Tab');
@@ -46,7 +46,7 @@ describe('Events', () => {
   });
 
   it('Should fire the change event only once when correcting the value according to step after pressing TAB', async () => {
-    const selector: string = '#testinput2';
+    const selector: string = '#testinput_step10_min';
 
     // Focus on the input element
     await page.focus(selector);
@@ -55,7 +55,7 @@ describe('Events', () => {
     await page.click(selector, { clickCount: 2 });
 
     // Type a new value
-    await page.keyboard.type('7');
+    await page.keyboard.type('67');
 
     // Press the TAB key to move out of the input field
     await page.keyboard.press('Tab');
@@ -67,7 +67,7 @@ describe('Events', () => {
   });
 
   it('Should fire the change event only once when correcting the value according to step after pressing Enter', async () => {
-    const selector: string = '#testinput2';
+    const selector: string = '#testinput_step10_min';
 
     // Focus on the input element
     await page.focus(selector);
@@ -76,7 +76,7 @@ describe('Events', () => {
     await page.click(selector, { clickCount: 2 });
 
     // Type a new value
-    await page.keyboard.type('7');
+    await page.keyboard.type('67');
 
     // Press the TAB key to move out of the input field
     await page.keyboard.press('Enter');
@@ -87,8 +87,8 @@ describe('Events', () => {
     expect(await touchspinHelpers.changeEventCounter(page)).toBe(1);
   });
 
-  it('Should fire the change event with the maximum value when the entered value was larger than the specified max value', async () => {
-    const selector: string = '#testinput2';
+  it('Should not fire change event when already at max value and entering a higher value', async () => {
+    const selector: string = '#testinput_step10_max';
 
     // Focus on the input element
     await page.focus(selector);
@@ -105,12 +105,12 @@ describe('Events', () => {
     // Wait for a short period to ensure all events are processed
     await touchspinHelpers.waitForTimeout(500);
 
-    expect(await touchspinHelpers.changeEventCounter(page)).toBe(1);
-    expect(await touchspinHelpers.countChangeWithValue(page, "100")).toBe(1);
+    expect(await touchspinHelpers.changeEventCounter(page)).toBe(0);
+    expect(await touchspinHelpers.countChangeWithValue(page, "100")).toBe(0);
   });
 
-  it('Should fire the change event with the minimum value when the entered value was lower than the specified min value', async () => {
-    const selector: string = '#testinput2';
+  it('Should not fire change event when already at min value and entering a lower value', async () => {
+    const selector: string = '#testinput_step10_min';
 
     // Focus on the input element
     await page.focus(selector);
@@ -127,7 +127,7 @@ describe('Events', () => {
     // Wait for a short period to ensure all events are processed
     await touchspinHelpers.waitForTimeout(500);
 
-    expect(await touchspinHelpers.changeEventCounter(page)).toBe(1);
-    expect(await touchspinHelpers.countChangeWithValue(page, "0")).toBe(1);
+    expect(await touchspinHelpers.changeEventCounter(page)).toBe(0);
+    expect(await touchspinHelpers.countChangeWithValue(page, "0")).toBe(0);
   });
 });

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -86,4 +86,48 @@ describe('Events', () => {
 
     expect(await touchspinHelpers.changeEventCounter(page)).toBe(1);
   });
+
+  it('Should fire the change event with the maximum value when the entered value was larger than the specified max value', async () => {
+    const selector: string = '#testinput2';
+
+    // Focus on the input element
+    await page.focus(selector);
+
+    // Clear the input
+    await page.click(selector, { clickCount: 2 });
+
+    // Type a new value
+    await page.keyboard.type('117');
+
+    // Press the TAB key to move out of the input field
+    await page.keyboard.press('Enter');
+
+    // Wait for a short period to ensure all events are processed
+    await touchspinHelpers.waitForTimeout(500);
+
+    expect(await touchspinHelpers.changeEventCounter(page)).toBe(1);
+    expect(await touchspinHelpers.countChangeWithValue(page, "100")).toBe(1);
+  });
+
+  it('Should fire the change event with the minimum value when the entered value was lower than the specified min value', async () => {
+    const selector: string = '#testinput2';
+
+    // Focus on the input element
+    await page.focus(selector);
+
+    // Clear the input
+    await page.click(selector, { clickCount: 2 });
+
+    // Type a new value
+    await page.keyboard.type('117');
+
+    // Press the TAB key to move out of the input field
+    await page.keyboard.press('Enter');
+
+    // Wait for a short period to ensure all events are processed
+    await touchspinHelpers.waitForTimeout(500);
+
+    expect(await touchspinHelpers.changeEventCounter(page)).toBe(1);
+    expect(await touchspinHelpers.countChangeWithValue(page, "0")).toBe(1);
+  });
 });

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -119,7 +119,7 @@ describe('Events', () => {
     await page.click(selector, { clickCount: 2 });
 
     // Type a new value
-    await page.keyboard.type('117');
+    await page.keyboard.type('-55');
 
     // Press the TAB key to move out of the input field
     await page.keyboard.press('Enter');

--- a/__tests__/helpers/touchspinHelpers.ts
+++ b/__tests__/helpers/touchspinHelpers.ts
@@ -55,7 +55,6 @@ async function countChangeWithValue(page: Page, expectedValue: string): Promise<
 
   // Count the number of 'change' events with the expected value
   const pattern = new RegExp('change\\[' + expectedValue + '\\]', 'g');
-  console.log(pattern);
   return (eventLogContent?.match(pattern) ?? []).length;
 }
 

--- a/__tests__/helpers/touchspinHelpers.ts
+++ b/__tests__/helpers/touchspinHelpers.ts
@@ -49,4 +49,14 @@ async function changeEventCounter(page: Page): Promise<number> {
   return (eventLogContent?.match(/change\[/g) ?? []).length;
 }
 
-export default { waitForTimeout, readInputValue, setInputAttr, checkTouchspinUpIsDisabled, touchspinClickUp, changeEventCounter };
+async function countChangeWithValue(page: Page, expectedValue: string): Promise<number> {
+  // Get the event log content
+  const eventLogContent = await page.$eval('#events_log', el => el.textContent);
+
+  // Count the number of 'change' events with the expected value
+  const pattern = new RegExp('change\\[' + expectedValue + '\\]', 'g');
+  console.log(pattern);
+  return (eventLogContent?.match(pattern) ?? []).length;
+}
+
+export default { waitForTimeout, readInputValue, setInputAttr, checkTouchspinUpIsDisabled, touchspinClickUp, changeEventCounter, countChangeWithValue };

--- a/__tests__/html/index.html
+++ b/__tests__/html/index.html
@@ -27,40 +27,51 @@
   <div class="row">
     <div class="col-md-4">
       <div class="wrapper">
-        <label for="testinput1">#testinput1:</label>
-        <input id="testinput1" type="text" value="50" name="testinput1">
+        <label for="testinput_default">#testinput_default:</label>
+        <input id="testinput_default" type="text" value="50" name="testinput_default">
 
         <script>
-          $("#testinput1").TouchSpin();
+          $("#testinput_default").TouchSpin();
         </script>
       </div>
 
       <div class="wrapper">
-        <label for="testinput2">#testinput2:</label>
-        <input id="testinput2" type="text" value="0" name="testinput2">
+        <label for="testinput_step10_min">#testinput_step10_min:</label>
+        <input id="testinput_step10_min" type="text" value="0" name="testinput_step10_min">
 
         <script>
-          $("#testinput2").TouchSpin({
+          $("#testinput_step10_min").TouchSpin({
             step: 10,
           });
         </script>
       </div>
 
       <div class="wrapper">
-        <label for="testinput3">#testinput3 (disabled):</label>
-        <input id="testinput3" type="text" value="0" name="testinput3" disabled>
+        <label for="testinput_step10_max">#testinput_step10_max:</label>
+        <input id="testinput_step10_max" type="text" value="100" name="testinput_step10_max">
 
         <script>
-          $("#testinput3").TouchSpin();
+          $("#testinput_step10_max").TouchSpin({
+            step: 10,
+          });
         </script>
       </div>
 
       <div class="wrapper">
-        <label for="testinput4">#testinput4 (readonly):</label>
-        <input id="testinput4" type="text" value="0" name="testinput4" readonly>
+        <label for="testinput_disabled">#testinput_disabled:</label>
+        <input id="testinput_disabled" type="text" value="0" name="testinput_disabled" disabled>
 
         <script>
-          $("#testinput4").TouchSpin();
+          $("#testinput_disabled").TouchSpin();
+        </script>
+      </div>
+
+      <div class="wrapper">
+        <label for="testinput_readonly">#testinput_readonly:</label>
+        <input id="testinput_readonly" type="text" value="0" name="testinput_readonly" readonly>
+
+        <script>
+          $("#testinput_readonly").TouchSpin();
         </script>
       </div>
     </div>

--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -336,7 +336,7 @@
             ev.preventDefault();
           }
           else if (code  ===  9 || code === 13)  {
-            originalinput.val(_forcestepdivisibility(originalinput.val()));
+            _checkValue();
           }
         });
 
@@ -601,6 +601,8 @@
           returnval = parsedval;
         }
 
+        returnval = _forcestepdivisibility(parsedval);
+
         if ((settings.min !== null) && (parsedval < settings.min)) {
           returnval = settings.min;
         }
@@ -609,9 +611,8 @@
           returnval = settings.max;
         }
 
-        if (parseFloat(val).toString() !== returnval.toString()) {
+        if (parseFloat(parsedval).toString() !== parseFloat(returnval).toString()) {
           originalinput.val(returnval);
-          originalinput.trigger('change');
         }
       }
 


### PR DESCRIPTION
Fixed bugs related to change events when an entered value was outside the min-max range, causing the plugin to correct the value. Now, the change event only fires with the correct value.