### PR TITLE
Fixing #104

### DIFF
--- a/__tests__/basicOperations.test.ts
+++ b/__tests__/basicOperations.test.ts
@@ -107,8 +107,8 @@ describe('Core functionality', () => {
 
     expect(await touchspinHelpers.readInputValue(page, selector)).toBe('57');
 
-    // Reaching 57 should fire the touchspin.on.max event twice
-    expect(await touchspinHelpers.countEvent(page, selector, 'touchspin.on.max')).toBe(2);
+    // Reaching 57 should fire the touchspin.on.max event three times (min is getting corrected to 45)
+    expect(await touchspinHelpers.countEvent(page, selector, 'touchspin.on.max')).toBe(3);
   });
 
   test("Bootstrap 3 should have input-group-sm class", async () => {

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -125,4 +125,16 @@ describe('Events', () => {
     expect(await touchspinHelpers.countChangeWithValue(page, '$1,000.00')).toBe(1);
   });
 
+  it('The touchspin.on.min and touchspin.on.max events should fire as soon as the value reaches the minimum or maximum value', async () => {
+    const selector: string = '#testinput_default';
+
+    await touchspinHelpers.fillWithValue(page, selector, '1');
+    await page.keyboard.press('ArrowDown');
+    expect(await touchspinHelpers.countEvent(page, selector, 'touchspin.on.min')).toBe(1);
+
+    await touchspinHelpers.fillWithValue(page, selector, '99');
+    await page.keyboard.press('ArrowUp');
+    expect(await touchspinHelpers.countEvent(page, selector, 'touchspin.on.max')).toBe(1);
+  });
+
 });

--- a/src/jquery.bootstrap-touchspin.js
+++ b/src/jquery.bootstrap-touchspin.js
@@ -757,7 +757,7 @@
           value = value + boostedstep;
         }
 
-        if ((settings.max !== null) && (value > settings.max)) {
+        if ((settings.max !== null) && (value >= settings.max)) {
           value = settings.max;
           originalinput.trigger('touchspin.on.max');
           stopSpin();
@@ -789,7 +789,7 @@
           value = value - boostedstep;
         }
 
-        if ((settings.min !== null) && (value < settings.min)) {
+        if ((settings.min !== null) && (value <= settings.min)) {
           value = settings.min;
           originalinput.trigger('touchspin.on.min');
           stopSpin();


### PR DESCRIPTION
Firing the min and max events as soon as the value reaches the minimum or the maximum. Beware that if step is not 1 then the minimum and maximum settings will be overwritten with the values that can be reached with the given step. Like if step is `3` and `min` is specified as `44` then the `touchspin.on.min` event will be fired as soon as the value reaches `45`, which is the minimum value that can be reached with the given step.