### PR TITLE
ci(release): fix npm authentication in changesets workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,6 @@ jobs:
       - name: Dry-run pack
         run: yarn workspaces foreach -A -v exec npm pack --dry-run
 
-      - name: Configure npm authentication
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish with Changesets
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
## Summary

Fixes the ENEEDAUTH errors that prevented package publishing in #169.

**Problem:** Manual ~/.npmrc creation was conflicting with changesets/action's built-in npm authentication mechanism. The action found the existing .npmrc but npm still couldn't authenticate, causing all publishes to fail.

**Solution:** Remove the manual "Configure npm authentication" step and let changesets/action@v1 handle npm auth internally via the NPM_TOKEN environment variable.

## Changes

- Removed manual npm auth step from release.yml
- changesets/action now handles npm authentication automatically using NPM_TOKEN env var

## Root Cause

The changesets/action has built-in npm authentication that:
1. Detects the NPM_TOKEN environment variable
2. Configures npm authentication properly for Yarn workspaces
3. Handles authentication for both `npm publish` and `yarn publish` commands

Our manual step was creating an .npmrc that conflicted with this internal mechanism.

## Test Plan

- [ ] Merge this PR
- [ ] Wait for release workflow to run on main
- [ ] Verify packages publish successfully to npm with alpha tag
- [ ] Check npm registry for published packages

## Related

- Fixes publish failures from #169
- Keeps all other improvements: concurrency control, provenance, duplicate CI fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)