### PR TITLE
ci: upload npm debug logs on release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Upload npm debug logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-debug-logs
+          path: /home/runner/work/touchspin/touchspin/.npm-cache/_logs/*.log


### PR DESCRIPTION
## Summary
<!-- What does this change do? One or two sentences. -->

## Checklist
- [ ] No new `any` — dynamic props go through a typed seam (`getCoreFromInput` or equivalent).
- [ ] Renderer-agnostic selectors only (`data-touchspin-injected="up|down|prefix|postfix"`).
- [ ] No test-level listeners — rely on centralized logging.
- [ ] Deterministic waits/expectations; no raw `waitForTimeout` in tests.
- [ ] Cheatsheet/handbook still match helper behavior (update if needed).
- [ ] (If touching Core API) Minimal interfaces only; avoid heavyweight deps.

## Screenshots / Notes (optional)

