### PR TITLE
ci(release): enable GitHub releases creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           version: yarn changeset version
           publish: yarn changeset publish
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Enables automatic GitHub release creation when publishing packages to npm.

**Issue:** Packages were successfully published to npm, but no corresponding GitHub releases were created.

**Solution:** Add `createGithubReleases: true` parameter to the `changesets/action@v1` configuration.

## Changes

```yaml
- name: Publish with Changesets
  uses: changesets/action@v1
  with:
    version: yarn changeset version
    publish: yarn changeset publish
    createGithubReleases: true  # ← Added
```

## Behavior After Merge

On the next release, changesets/action will:
1. Publish packages to npm (as before)
2. Create GitHub releases for each published package
3. Use changeset descriptions as release notes

## Example

For `@touchspin/core@5.0.1-alpha.0`, a GitHub release will be created at:
`https://github.com/istvan-ujjmeszaros/touchspin/releases/tag/@touchspin/core@5.0.1-alpha.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)