### PR TITLE
fix: build dependencies in correct order to avoid circular dependency…

### DIFF
--- a/scripts/create-release-assets.mjs
+++ b/scripts/create-release-assets.mjs
@@ -41,9 +41,15 @@ if (!packagesJson || packagesJson === '[]') {
 async function buildReleaseAssets() {
   console.log('Building minified release assets...');
 
-  // Build all dependencies first
-  console.log('Building dependencies...');
-  await runCommand('yarn workspaces foreach -pt -A run build');
+  // Build dependencies in correct order to avoid circular dependencies
+  console.log('Building core dependencies...');
+  await runCommand('yarn workspace @touchspin/core run build');
+
+  console.log('Building renderer dependencies...');
+  await runCommand('yarn workspaces foreach -pt -A --include "@touchspin/renderer-*" run build');
+
+  console.log('Building adapter dependencies...');
+  await runCommand('yarn workspaces foreach -pt -A --include "@touchspin/standalone" run build');
 
   // Build jQuery release assets
   console.log('Building jQuery release assets...');


### PR DESCRIPTION
… errors

- Build core first, then renderers, then adapters
- Prevents renderer packages from failing when core isn't built yet

## Summary
<!-- What does this change do? One or two sentences. -->

## Checklist
- [ ] No new `any` — dynamic props go through a typed seam (`getCoreFromInput` or equivalent).
- [ ] Renderer-agnostic selectors only (`data-touchspin-injected="up|down|prefix|postfix"`).
- [ ] No test-level listeners — rely on centralized logging.
- [ ] Deterministic waits/expectations; no raw `waitForTimeout` in tests.
- [ ] Cheatsheet/handbook still match helper behavior (update if needed).
- [ ] (If touching Core API) Minimal interfaces only; avoid heavyweight deps.

## Screenshots / Notes (optional)

