### PR TITLE
fix: add inputmode hint when callbacks force text

### DIFF
--- a/.changeset/formatter-inputmode-hint.md
+++ b/.changeset/formatter-inputmode-hint.md
@@ -1,0 +1,5 @@
+---
+"@touchspin/core": patch
+---
+
+Ensure callback-driven type conversions also add an appropriate `inputmode` hint so decorated text inputs keep numeric keyboards while preserving author-provided attributes.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -461,10 +461,25 @@ export class TouchSpinCore {
       // Convert input type to text to support formatting
       this.input.setAttribute('type', 'text');
 
-      // Remove number-specific native attributes since they only work on number inputs
-      this.input.removeAttribute('min');
-      this.input.removeAttribute('max');
-      this.input.removeAttribute('step');
+      // Hint preferred virtual keyboard if not already specified
+      const step = this.settings.step ?? 1;
+      const decimalsSetting = this.settings.decimals ?? 0;
+      const hasDecimals = decimalsSetting > 0 || step % 1 !== 0;
+      const minSetting = this.settings.min ?? null;
+      const allowNegative =
+        minSetting === null || (typeof minSetting === 'number' && minSetting < 0);
+      if (!this.input.hasAttribute('inputmode')) {
+        const inputMode = hasDecimals || allowNegative ? 'decimal' : 'numeric';
+        this.input.setAttribute('inputmode', inputMode);
+      }
+
+      // Remove native number attributes only if TouchSpin added them
+      ['min', 'max', 'step'].forEach((attr) => {
+        const originalValue = this._originalAttributes?.attributes.get(attr) ?? null;
+        if (originalValue === null) {
+          this.input.removeAttribute(attr);
+        }
+      });
     }
   }
 
@@ -485,6 +500,7 @@ export class TouchSpinCore {
       'min',
       'max',
       'step',
+      'inputmode',
     ];
 
     this._originalAttributes = {

--- a/packages/core/tests/specs/coverage-enhancements.spec.ts
+++ b/packages/core/tests/specs/coverage-enhancements.spec.ts
@@ -77,6 +77,7 @@ test.describe('Core edge-case coverage', () => {
           hasMin: input.hasAttribute('min'),
           hasMax: input.hasAttribute('max'),
           hasStep: input.hasAttribute('step'),
+          inputmode: input.getAttribute('inputmode'),
         };
 
         instance.destroy();
@@ -86,6 +87,7 @@ test.describe('Core edge-case coverage', () => {
           min: input.getAttribute('min'),
           max: input.getAttribute('max'),
           step: input.getAttribute('step'),
+          inputmode: input.getAttribute('inputmode'),
         };
 
         return { afterInit, restored };
@@ -94,14 +96,16 @@ test.describe('Core edge-case coverage', () => {
     );
 
     expect(result.afterInit.type).toBe('text');
-    expect(result.afterInit.hasMin).toBe(false);
-    expect(result.afterInit.hasMax).toBe(false);
-    expect(result.afterInit.hasStep).toBe(false);
+    expect(result.afterInit.hasMin).toBe(true);
+    expect(result.afterInit.hasMax).toBe(true);
+    expect(result.afterInit.hasStep).toBe(true);
+    expect(result.afterInit.inputmode).toBe('numeric');
 
     expect(result.restored.type).toBe('number');
     expect(result.restored.min).toBe('0');
     expect(result.restored.max).toBe('100');
     expect(result.restored.step).toBe('5');
+    expect(result.restored.inputmode).toBeNull();
   });
 
   /**


### PR DESCRIPTION
## Summary
- ensure formatter-triggered text conversion adds the proper inputmode hint
- only drop native number attributes when TouchSpin injected them
- document restoration via updated coverage spec and changeset